### PR TITLE
Update packaging config to allow installation via brooklyn.libraries

### DIFF
--- a/catalog/catalog.bom
+++ b/catalog/catalog.bom
@@ -1,0 +1,3 @@
+brooklyn.catalog:
+  items:
+  - classpath://jenkins/jenkins.bom


### PR DESCRIPTION
To install a bundle via a bom file and brooklyn.libraries, you need to have:

- a valid OSGi bundle (was already there)
- a `catalog.bom` at the root of the bundle, which this PR adds